### PR TITLE
Added a configurable distance variable to pinch gesture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ right = ""
 [commands.pinch]
 in = ""
 out = ""
+distance=""
 ```
+
+* `distance` variable in `commands.pinch` sets the distance between fingers where it shold trigger.
+  Defaults to `0.5` which means fingers should travel exactly half way from their initial position.
+
 
 ### Repository versions
 
@@ -95,6 +100,7 @@ right = "bspc desktop -f next"
 [commands.pinch]
 in = "xdotool key Control_L+equal"
 out = "xdotool key Control_L+minus"
+ditance="0.1"
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -61,8 +61,9 @@ void gebaar::config::Config::load_config()
             swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
             swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
 
-            pinch_commands[0] = *config->get_qualified_as<std::string>("commands.pinch.out");
-            pinch_commands[1] = *config->get_qualified_as<std::string>("commands.pinch.in");
+            pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
+            pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
+            pinch_commands[DISTANCE] = *config->get_qualified_as<std::string>("commands.pinch.distance");
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,6 +33,9 @@ namespace gebaar::config {
 
         void load_config();
 
+
+        enum pinches {PINCH_IN, PINCH_OUT, DISTANCE};
+
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
         std::string pinch_commands[10];

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -24,6 +24,10 @@
 #include <zconf.h>
 #include "../config/config.h"
 
+#define DEFAULT_SCALE    1.0
+#define DEFAULT_DISTANCE 0.5
+
+
 namespace gebaar::io {
     struct gesture_swipe_event {
         int fingers;
@@ -35,6 +39,8 @@ namespace gebaar::io {
         int fingers;
         double scale;
         double angle;
+
+        double distance;
         bool executed;
     };
 


### PR DESCRIPTION
I felt that pinch gesture is kinda tricky to execute on touchpad,
so I changed a way of calculation when to trigger the command and
added the distance for fingers travel to configuration.
Basically a `0.5` distance feels quite ok to me, but it becomes really
snappy at `0.1`.